### PR TITLE
Add WrappedRoundTripper method to addQuery transport

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -40,6 +40,10 @@ func (a *addQuery) RoundTrip(req *http.Request) (*http.Response, error) {
 	return a.next.RoundTrip(req)
 }
 
+func (a *addQuery) WrappedRoundTripper() http.RoundTripper {
+	return a.next
+}
+
 func NewFactory(cfg *rest.Config, impersonate bool) (*Factory, error) {
 	clientCfg := rest.CopyConfig(cfg)
 	clientCfg.QPS = 10000


### PR DESCRIPTION
This allows cancellation requests to be passed to wrapped RoundTrippers
instead of terminating with a log message at addQuery.

See https://github.com/kubernetes/client-go/blob/96e9c8d6f10a7c40a7bd95e0723b18808227b315/transport/transport.go#L353

